### PR TITLE
Checking for undefined filePath

### DIFF
--- a/lib/auto-uglify.coffee
+++ b/lib/auto-uglify.coffee
@@ -7,7 +7,7 @@ compile = () ->
   if activeEditor
     filePath = activeEditor.getPath()
 
-    if filePath.indexOf('.js') == filePath.length - 3 and filePath.indexOf('.min.js') == -1
+    if filePath != undefined and filePath.indexOf('.js') == filePath.length - 3 and filePath.indexOf('.min.js') == -1
       text = activeEditor.getText()
       result = UglifyJS.minify(text, {fromString: true});
 


### PR DESCRIPTION
This fix works for me to avoid the Uncaught TypeError exception (issue #1) when saving new files for the first time
